### PR TITLE
Configuration can be loaded or passed; Added gpu_id parameter

### DIFF
--- a/botsort/CMakeLists.txt
+++ b/botsort/CMakeLists.txt
@@ -20,7 +20,10 @@ file(GLOB_RECURSE SOURCES "${PROJECT_SOURCE_DIR}/src/*.cpp")
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
 
 # Set include directories
-target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 
 # Find and link OpenCV
 find_package(OpenCV REQUIRED)

--- a/botsort/include/BoTSORT.h
+++ b/botsort/include/BoTSORT.h
@@ -1,19 +1,26 @@
 #pragma once
 
 #include <string>
+#include <variant>
 
 #include "GlobalMotionCompensation.h"
+#include "GmcParams.h"
 #include "ReID.h"
+#include "ReIDParams.h"
+#include "TrackerParams.h"
 #include "track.h"
 
+template<typename T>
+using Config = std::variant<T, std::string, std::monostate>;
 
 class BoTSORT
 {
 public:
-    explicit BoTSORT(const std::string &tracker_config_path,
-                     const std::string &gmc_config_path = "",
-                     const std::string &reid_config_path = "",
+    explicit BoTSORT(const Config<TrackerParams> &tracker_config,
+                     const Config<GMC_Params> &gmc_config = {},
+                     const Config<ReIDParams> &reid_config = {},
                      const std::string &reid_onnx_model_path = "");
+
     ~BoTSORT() = default;
 
 
@@ -79,14 +86,12 @@ private:
             std::vector<std::shared_ptr<Track>> &tracks_list_a,
             std::vector<std::shared_ptr<Track>> &tracks_list_b);
 
-
     /**
-     * @brief Load tracker parameters from the given config file
+     * @brief Load tracker parameters from the given config
      * 
-     * @param config_path Path to the config directory
+     * @param config Configuration to load
      */
-    void _load_params_from_config(const std::string &config_path);
-
+    void _load_params_from_config(const TrackerParams &config);
 
 private:
     std::string _gmc_method_name;

--- a/botsort/include/GlobalMotionCompensation.h
+++ b/botsort/include/GlobalMotionCompensation.h
@@ -6,6 +6,7 @@
 
 // .clang-format off
 #include "DataType.h"
+#include "GmcParams.h"
 // .clang-format on
 
 #include <opencv2/core/eigen.hpp>
@@ -15,16 +16,6 @@
 #include <opencv2/opencv.hpp>
 #include <opencv2/videostab.hpp>
 #include <opencv2/videostab/global_motion.hpp>
-
-
-enum GMC_Method
-{
-    ORB = 0,
-    ECC,
-    SparseOptFlow,
-    OptFlowModified,
-    OpenCV_VideoStab
-};
 
 
 class GMC_Algorithm
@@ -39,13 +30,13 @@ public:
 class ORB_GMC : public GMC_Algorithm
 {
 public:
-    explicit ORB_GMC(const std::string &config_path);
+    explicit ORB_GMC(const ORB_Params &orb_config);
     HomographyMatrix apply(const cv::Mat &frame_raw,
                            const std::vector<Detection> &detections) override;
 
 
 private:
-    void _load_params_from_config(const std::string &config_path);
+    void _load_params_from_config(const ORB_Params &orb_config);
 
 
 private:
@@ -67,13 +58,13 @@ private:
 class ECC_GMC : public GMC_Algorithm
 {
 public:
-    explicit ECC_GMC(const std::string &config_path);
+    explicit ECC_GMC(const ECC_Params &config);
     HomographyMatrix apply(const cv::Mat &frame_raw,
                            const std::vector<Detection> &detections) override;
 
 
 private:
-    void _load_params_from_config(const std::string &config_dir);
+    void _load_params_from_config(const ECC_Params &config);
 
 
 private:
@@ -91,13 +82,13 @@ private:
 class SparseOptFlow_GMC : public GMC_Algorithm
 {
 public:
-    explicit SparseOptFlow_GMC(const std::string &config_path);
+    explicit SparseOptFlow_GMC(const SparseOptFlow_Params &config);
     HomographyMatrix apply(const cv::Mat &frame_raw,
                            const std::vector<Detection> &detections) override;
 
 
 private:
-    void _load_params_from_config(const std::string &config_dir);
+    void _load_params_from_config(const SparseOptFlow_Params &config);
 
 
 private:
@@ -119,13 +110,13 @@ private:
 class OptFlowModified_GMC : public GMC_Algorithm
 {
 public:
-    explicit OptFlowModified_GMC(const std::string &config_path);
+    explicit OptFlowModified_GMC(const OptFlowModified_Params &config);
     HomographyMatrix apply(const cv::Mat &frame_raw,
                            const std::vector<Detection> &detections) override;
 
 
 private:
-    void _load_params_from_config(const std::string &config_dir);
+    void _load_params_from_config(const OptFlowModified_Params &config);
 
 
 private:
@@ -137,13 +128,13 @@ private:
 class OpenCV_VideoStab_GMC : public GMC_Algorithm
 {
 public:
-    explicit OpenCV_VideoStab_GMC(const std::string &config_path);
+    explicit OpenCV_VideoStab_GMC(const OpenCV_VideoStab_GMC_Params &config);
     HomographyMatrix apply(const cv::Mat &frame_raw,
                            const std::vector<Detection> &detections) override;
 
 
 private:
-    void _load_params_from_config(const std::string &config_dir);
+    void _load_params_from_config(const OpenCV_VideoStab_GMC_Params &config);
 
 
 private:
@@ -167,11 +158,9 @@ public:
     /**
      * @brief Construct a new Global Motion Compensation object
      * 
-     * @param method GMC_Method enum member for GMC algorithm to use
-     * @param config_dir Directory containing config files for GMC algorithm
+     * @param gmc_params Paramerters for GMC algorithm
      */
-    explicit GlobalMotionCompensation(GMC_Method method,
-                                      const std::string &config_path);
+    explicit GlobalMotionCompensation(const GMC_Params &gmc_params);
     ~GlobalMotionCompensation() = default;
 
     /**

--- a/botsort/include/GmcParams.h
+++ b/botsort/include/GmcParams.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <string>
+#include <variant>
+
+enum GMC_Method
+{
+    ORB = 0,
+    ECC,
+    SparseOptFlow,
+    OptFlowModified,
+    OpenCV_VideoStab
+};
+
+struct ORB_Params
+{
+    float downscale{2.f};
+    float inlier_ratio{0.5f};
+    float ransac_conf{.99f};
+    long ransac_max_iters{500};
+};
+
+struct ECC_Params
+{
+    float downscale{5.f};
+    long max_iterations{100};
+    float termination_eps{1e-6};
+};
+
+struct SparseOptFlow_Params
+{
+    long max_corners{1000};
+    long block_size{3};
+    long ransac_max_iters{500};
+    double quality_level{0.01};
+    double k{0.04};
+    double min_distance{1.0};
+    float downscale{2.0f};
+    float inlier_ratio{0.5f};
+    float ransac_conf{0.99f};
+    bool use_harris_detector{false};
+};
+
+struct OptFlowModified_Params
+{
+    float downscale{2.0f};
+};
+
+struct OpenCV_VideoStab_GMC_Params
+{
+    float downscale{2.0f};
+    float num_features{4000};
+    bool detection_masking{true};
+};
+
+struct GMC_Params
+{
+    using MethodParams =
+            std::variant<ORB_Params, ECC_Params, SparseOptFlow_Params,
+                         OptFlowModified_Params, OpenCV_VideoStab_GMC_Params,
+                         std::monostate>;
+
+    GMC_Method method_;
+    MethodParams method_params_;
+
+    static GMC_Params load_config(GMC_Method method,
+                                  const std::string &config_path);
+};

--- a/botsort/include/INIReader.h
+++ b/botsort/include/INIReader.h
@@ -359,45 +359,74 @@ public:
     }
 
     // Return the list of sections found in ini file
-    const std::set<std::string> &Sections() const;
+    [[nodiscard]] const std::set<std::string> &Sections() const;
 
     // Get a string value from INI file, returning default_value if not found.
-    std::string Get(const std::string &section, const std::string &name,
-                    const std::string &default_value) const;
+    [[nodiscard]] std::string Get(const std::string &section,
+                                  const std::string &name,
+                                  const std::string &default_value) const;
 
 
     // Get a string value from INI file, return nullopt if not found.
-    std::optional<std::string> Get(const std::string &section,
-                                   const std::string &name) const;
+    [[nodiscard]] std::optional<std::string> Get(const std::string &section,
+                                                 const std::string &name) const;
 
 
     // Get an integer (long) value from INI file, returning default_value if
     // not found or not a valid integer (decimal "1234", "-1234", or hex "0x4d2").
-    long GetInteger(const std::string &section, const std::string &name,
-                    long default_value) const;
+    [[nodiscard]] long GetInteger(const std::string &section,
+                                  const std::string &name,
+                                  long default_value) const;
 
     // Get a real (floating point double) value from INI file, returning
     // default_value if not found or not a valid floating point value
     // according to strtod().
-    double GetReal(const std::string &section, const std::string &name,
-                   double default_value) const;
+    [[nodiscard]] double GetReal(const std::string &section,
+                                 const std::string &name,
+                                 double default_value) const;
 
     // Get a single precision floating point number value from INI file, returning
     // default_value if not found or not a valid floating point value
     // according to strtof().
-    float GetFloat(const std::string &section, const std::string &name,
-                   float default_value) const;
+    [[nodiscard]] float GetFloat(const std::string &section,
+                                 const std::string &name,
+                                 float default_value) const;
 
     // Get a boolean value from INI file, returning default_value if not found or if
     // not a valid true/false value. Valid true values are "true", "yes", "on", "1",
     // and valid false values are "false", "no", "off", "0" (not case sensitive).
-    bool GetBoolean(const std::string &section, const std::string &name,
-                    bool default_value) const;
+    [[nodiscard]] bool GetBoolean(const std::string &section,
+                                  const std::string &name,
+                                  bool default_value) const;
 
     template<typename T>
-    std::vector<T> GetList(const std::string &section,
-                           const std::string &name) const;
+    [[nodiscard]] std::vector<T> GetList(const std::string &section,
+                                         const std::string &name) const;
 
+    // Load a string value from INI file, returning its value if successfully
+    // loaded, or leave value unchanged
+    void LoadString(const std::string &section, const std::string &name,
+                    std::string &value) const;
+
+    // Load an integer (long) value from INI file, returning its value if
+    // successfully loaded, or leave value unchanged
+    void LoadInteger(const std::string &section, const std::string &name,
+                     long &value) const;
+
+    // Load a real (floating point double) value from INI file, returning its
+    // value if successfully loaded, or leave value unchanged
+    void LoadReal(const std::string &section, const std::string &name,
+                  double &value) const;
+
+    // Load a single precision floating point number value from INI file, returning
+    // its value if successfully loaded, or leave value unchanged
+    void LoadFloat(const std::string &section, const std::string &name,
+                   float &value) const;
+
+    // Load a boolean value from INI file, returning its value if successfully
+    // loaded, or leave value unchanged
+    void LoadBoolean(const std::string &section, const std::string &name,
+                     bool &value) const;
 
 protected:
     int _error;
@@ -566,6 +595,37 @@ std::vector<T> INIReader::GetList(const std::string &section,
         }
     }
     return list_items;
+}
+
+inline void INIReader::LoadString(const std::string &section,
+                                  const std::string &name,
+                                  std::string &value) const
+{
+    value = Get(section, name, value);
+}
+
+inline void INIReader::LoadInteger(const std::string &section,
+                                   const std::string &name, long &value) const
+{
+    value = GetInteger(section, name, value);
+}
+
+inline void INIReader::LoadReal(const std::string &section,
+                                const std::string &name, double &value) const
+{
+    value = GetReal(section, name, value);
+}
+
+inline void INIReader::LoadFloat(const std::string &section,
+                                 const std::string &name, float &value) const
+{
+    value = GetFloat(section, name, value);
+}
+
+inline void INIReader::LoadBoolean(const std::string &section,
+                                   const std::string &name, bool &value) const
+{
+    value = GetBoolean(section, name, value);
 }
 
 #endif// __INIREADER__

--- a/botsort/include/ReID.h
+++ b/botsort/include/ReID.h
@@ -3,13 +3,13 @@
 #include <opencv2/core.hpp>
 
 #include "DataType.h"
+#include "ReIDParams.h"
 #include "TRT_InferenceEngine/TensorRT_InferenceEngine.h"
 
 class ReIDModel
 {
 public:
-    ReIDModel(const std::string &config_path,
-              const std::string &onnx_model_path);
+    ReIDModel(const ReIDParams &params, const std::string &onnx_model_path);
     ~ReIDModel() = default;
 
     void pre_process(cv::Mat &image);
@@ -21,7 +21,7 @@ public:
     }
 
 private:
-    void _load_params_from_config(const std::string &config_path);
+    void _load_params_from_config(const ReIDParams &params);
 
 
 private:

--- a/botsort/include/ReIDParams.h
+++ b/botsort/include/ReIDParams.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct ReIDParams
+{
+    long gpu_id{0};
+    std::string distance_metric{"euclidean"};
+    long trt_logging_level{1};
+    long batch_size{1};
+    std::string input_layer_name{""};
+    std::vector<int> input_layer_dimensions;
+    std::vector<std::string> output_layer_names;
+
+    bool enable_fp16{true};
+    bool enable_tf32{true};
+    bool swap_rb{false};
+
+    static ReIDParams load_config(const std::string &config_path);
+};

--- a/botsort/include/TRT_InferenceEngine/TensorRT_InferenceEngine.h
+++ b/botsort/include/TRT_InferenceEngine/TensorRT_InferenceEngine.h
@@ -2,11 +2,11 @@
 
 #include <eigen3/Eigen/Core>
 #include <eigen3/Eigen/Dense>
+#include <fstream>
 #include <memory>
 #include <numeric>
 #include <string>
 #include <vector>
-#include <fstream>
 
 #include <NvInfer.h>
 #include <NvOnnxParser.h>
@@ -55,6 +55,7 @@ struct TRTOptimizerParams
 {
     TRTOptimizerParams() = default;
 
+    int gpu_id = 0;
     int batch_size = 1;
     bool fp16 = true;
     bool int8 = false;
@@ -69,7 +70,8 @@ struct TRTOptimizerParams
 
     std::string toStr()
     {
-        std::string str = "batch_size: " + std::to_string(batch_size) + "\n";
+        std::string str = "gpu_id:" + std::to_string(gpu_id) + "\n";
+        str += "batch_size: " + std::to_string(batch_size) + "\n";
         str += "fp16: " + std::to_string(fp16) + "\n";
         str += "int8: " + std::to_string(int8) + "\n";
         str += "tf32: " + std::to_string(tf32) + "\n";

--- a/botsort/include/TrackerParams.h
+++ b/botsort/include/TrackerParams.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+struct TrackerParams
+{
+    bool reid_enabled{false};
+    bool gmc_enabled{false};
+    float track_high_thresh{0.6F};
+    float track_low_thresh{0.1F};
+    float new_track_thresh{0.7F};
+    long track_buffer{30};
+    float match_thresh{0.7F};
+    float proximity_thresh{0.5F};
+    float appearance_thresh{0.25F};
+    std::string gmc_method_name{"sparseOptFlow"};
+    long frame_rate{30};
+    float lambda{0.985F};
+
+    static TrackerParams load_config(const std::string &config_path);
+};

--- a/botsort/include/track.h
+++ b/botsort/include/track.h
@@ -78,6 +78,13 @@ public:
     float get_score() const;
 
     /**
+     * @brief Get the class ID of the track
+     * 
+     * @return uint8_t Class ID of the track
+     */
+    uint8_t get_class_id() const;
+
+    /**
      * @brief Activates the track
      * 
      * @param kalman_filter Kalman filter object for the track

--- a/botsort/src/GmcParams.cpp
+++ b/botsort/src/GmcParams.cpp
@@ -1,0 +1,116 @@
+#include "GmcParams.h"
+
+#include <iostream>
+
+#include "DataType.h"
+#include "INIReader.h"
+
+constexpr std::size_t NUM_METHODS{5};
+
+using MethodLoaderFunction = GMC_Params::MethodParams (*)(INIReader &);
+
+namespace
+{
+GMC_Params::MethodParams load_orb_config(INIReader &gmc_config)
+{
+    ORB_Params params{};
+    static constexpr auto SECTION = "orb";
+
+    gmc_config.LoadFloat(SECTION, "downscale", params.downscale);
+    gmc_config.LoadFloat(SECTION, "inlier_ratio", params.inlier_ratio);
+    gmc_config.LoadFloat(SECTION, "ransac_conf", params.ransac_conf);
+    gmc_config.LoadInteger(SECTION, "ransac_max_iters",
+                           params.ransac_max_iters);
+
+    return {params};
+}
+
+GMC_Params::MethodParams load_ecc_config(INIReader &gmc_config)
+{
+    ECC_Params params{};
+    static constexpr auto SECTION = "ecc";
+
+    gmc_config.LoadFloat(SECTION, "downscale", params.downscale);
+    gmc_config.LoadInteger(SECTION, "max_iterations", params.max_iterations);
+    gmc_config.LoadFloat(SECTION, "termination_eps", params.termination_eps);
+
+    return {params};
+}
+
+GMC_Params::MethodParams load_sparce_config(INIReader &gmc_config)
+{
+    SparseOptFlow_Params params{};
+    static constexpr auto SECTION = "sparseOptFlow";
+
+    gmc_config.LoadBoolean(SECTION, "use_harris_detector",
+                           params.use_harris_detector);
+
+    gmc_config.LoadInteger(SECTION, "max_corners", params.max_corners);
+    gmc_config.LoadInteger(SECTION, "block_size", params.block_size);
+    gmc_config.LoadInteger(SECTION, "ransac_max_iters",
+                           params.ransac_max_iters);
+
+    gmc_config.LoadReal(SECTION, "quality_level", params.quality_level);
+    gmc_config.LoadReal(SECTION, "k", params.k);
+    gmc_config.LoadReal(SECTION, "min_distance", params.min_distance);
+
+    gmc_config.LoadFloat(SECTION, "downscale", params.downscale);
+    gmc_config.LoadFloat(SECTION, "inlier_ratio", params.inlier_ratio);
+    gmc_config.LoadFloat(SECTION, "ransac_conf", params.ransac_conf);
+
+    return {params};
+}
+
+GMC_Params::MethodParams load_opt_config(INIReader &gmc_config)
+{
+    OptFlowModified_Params params{};
+    static constexpr auto SECTION = "OptFlowModified";
+
+    gmc_config.LoadFloat(SECTION, "downscale", params.downscale);
+
+    return params;
+}
+
+GMC_Params::MethodParams load_videostab_config(INIReader &gmc_config)
+{
+    OpenCV_VideoStab_GMC_Params params{};
+    static constexpr auto SECTION = "OptFlowModified";
+
+    gmc_config.LoadFloat(SECTION, "downscale", params.downscale);
+    gmc_config.LoadFloat(SECTION, "num_features", params.num_features);
+    gmc_config.LoadBoolean(SECTION, "detections_masking",
+                           params.detection_masking);
+
+    return params;
+}
+}// namespace
+
+GMC_Params GMC_Params::load_config(GMC_Method method,
+                                   const std::string &config_path)
+{
+    GMC_Params config;
+    config.method_ = method;
+
+    static std::array<MethodLoaderFunction, NUM_METHODS> method_loaders = {
+            load_orb_config, load_ecc_config, load_sparce_config,
+            load_opt_config, load_videostab_config};
+
+    auto method_index = static_cast<std::size_t>(method);
+    if (method_index >= NUM_METHODS)
+    {
+        throw std::runtime_error("Unknown global motion compensation method: " +
+                                 std::to_string(method));
+    }
+
+    INIReader gmc_config(config_path);
+    if (gmc_config.ParseError() < 0)
+    {
+        std::cout << "Can't load " << config_path << std::endl;
+        exit(1);
+    }
+
+    config.method_params_ =
+            method_loaders[static_cast<std::size_t>(method)](gmc_config);
+
+    return config;
+}

--- a/botsort/src/ReIDParams.cpp
+++ b/botsort/src/ReIDParams.cpp
@@ -1,0 +1,41 @@
+#include "ReIDParams.h"
+
+#include <iostream>
+
+#include "DataType.h"
+#include "INIReader.h"
+
+
+ReIDParams ReIDParams::load_config(const std::string &config_path)
+{
+    ReIDParams config{};
+
+    const std::string reid_name = "ReID";
+
+    INIReader reid_config(config_path);
+    if (reid_config.ParseError() < 0)
+    {
+        std::cout << "Can't load " << config_path << std::endl;
+        exit(1);
+    }
+
+    reid_config.LoadInteger(reid_name, "gpu_id", config.gpu_id);
+    reid_config.LoadString(reid_name, "distance_metric",
+                           config.distance_metric);
+    reid_config.LoadInteger(reid_name, "trt_logging_level",
+                            config.trt_logging_level);
+    reid_config.LoadInteger(reid_name, "batch_size", config.batch_size);
+    reid_config.LoadString(reid_name, "input_layer_name",
+                           config.input_layer_name);
+
+    reid_config.LoadBoolean(reid_name, "enable_fp16", config.enable_fp16);
+    reid_config.LoadBoolean(reid_name, "enable_tf32", config.enable_tf32);
+    reid_config.LoadBoolean(reid_name, "swapRB", config.swap_rb);
+
+    config.input_layer_dimensions =
+            reid_config.GetList<int>(reid_name, "input_layer_dimensions");
+    config.output_layer_names =
+            reid_config.GetList<std::string>(reid_name, "output_layer_names");
+
+    return config;
+}

--- a/botsort/src/TrackerParams.cpp
+++ b/botsort/src/TrackerParams.cpp
@@ -1,0 +1,44 @@
+#include "TrackerParams.h"
+
+#include <iostream>
+
+#include "DataType.h"
+#include "INIReader.h"
+
+
+TrackerParams TrackerParams::load_config(const std::string &config_path)
+{
+    TrackerParams config{};
+
+    const std::string tracker_name = "BoTSORT";
+
+    INIReader tracker_config(config_path);
+    if (tracker_config.ParseError() < 0)
+    {
+        std::cout << "Can't load " << config_path << std::endl;
+        exit(1);
+    }
+
+    tracker_config.LoadBoolean(tracker_name, "enable_reid",
+                               config.reid_enabled);
+    tracker_config.LoadBoolean(tracker_name, "enable_gmc", config.gmc_enabled);
+    tracker_config.LoadFloat(tracker_name, "track_high_thresh",
+                             config.track_high_thresh);
+    tracker_config.LoadFloat(tracker_name, "track_low_thresh",
+                             config.track_low_thresh);
+    tracker_config.LoadFloat(tracker_name, "new_track_thresh",
+                             config.new_track_thresh);
+    tracker_config.LoadInteger(tracker_name, "track_buffer",
+                               config.track_buffer);
+    tracker_config.LoadFloat(tracker_name, "match_thresh", config.match_thresh);
+    tracker_config.LoadFloat(tracker_name, "proximity_thresh",
+                             config.proximity_thresh);
+    tracker_config.LoadFloat(tracker_name, "appearance_thresh",
+                             config.appearance_thresh);
+    tracker_config.LoadString(tracker_name, "gmc_method",
+                              config.gmc_method_name);
+    tracker_config.LoadInteger(tracker_name, "frame_rate", config.frame_rate);
+    tracker_config.LoadFloat(tracker_name, "lambda", config.lambda);
+
+    return config;
+}

--- a/botsort/src/track.cpp
+++ b/botsort/src/track.cpp
@@ -228,6 +228,11 @@ float Track::get_score() const
     return _score;
 }
 
+uint8_t Track::get_class_id() const
+{
+    return _class_id;
+}
+
 void Track::_update_class_id(uint8_t class_id, float score)
 {
     if (!_class_hist.empty())


### PR DESCRIPTION
## Description

This update introduces enhanced configuration flexibility: configurations can now be specified either as a string pointing to an INI file or as a struct containing the configuration parameters.

### Motivation
1. **Dynamic Configuration Updates**: Parameters can now be modified at runtime based on dynamic information (e.g., assigned GPU).
2. **Seamless Integration**: The use of structs allows for easier integration with the user’s application-specific parameter management components.

### Summary of Changes
1. **Configuration Flexibility**:
   - A configuration can now be:
     - **A string**: Path to an INI configuration file.
     - **A struct**: Directly containing configuration parameters.
   - For GMC configurations, the struct-based approach applies one level deeper, allowing configurations to represent various classes (e.g., ORB, ECC).
   - Structs now hold the default values of the parameters
   - **Backward Compatibility**: No changes are required for users interacting via the `BotSORT` class. However, users directly accessing specific components of the library will need to use parameter structs, as `BotSORT` now handles loading parameters into structs.
2. **New INI function set**
 - A new set of `Load` functions as been added that takes the variable in which to store the value in but leaves the value unchanged if it is not present in the INI file. This is important since the default values are in the structs, not in the loading from the file
 - Added `[[nodiscard]]` to the `Get` function set so that warnings will be thrown if a value was discarded. This is to help mitigate issues with the usage of `Get` when it should have been `Load`, 
3. **New ReID Parameter**:
   - A `gpu_id` parameter has been added to specify which GPU a model should use in multi-GPU environments.
   - This change also affects the naming convention of the generated engine file, which now includes the target GPU name.
   - **Backward Compatibility**: Due to the name changes, engine files will either need to be re-generated or manually renamed

4. **Track ID Retrieval**:
   - A minor addition enables the retrieval of a track's ID.