### PR TITLE
Fix runtime ownership for TensorRT

### DIFF
--- a/botsort/include/TRT_InferenceEngine/TensorRT_InferenceEngine.h
+++ b/botsort/include/TRT_InferenceEngine/TensorRT_InferenceEngine.h
@@ -98,6 +98,8 @@ private:
     nvinfer1::ILogger::Severity _logSeverity =
             nvinfer1::ILogger::Severity::kWARNING;
     TRTOptimizerParams _optimization_params;
+    // Runtime must outlive the engine and execution context.
+    TRTUniquePtr<nvinfer1::IRuntime> _runtime{nullptr};
     TRTUniquePtr<nvinfer1::ICudaEngine> _engine{nullptr};
     TRTUniquePtr<nvinfer1::IExecutionContext> _context{nullptr};
     std::unique_ptr<TRTLogger> _logger{nullptr};

--- a/botsort/src/TRT_InferenceEngine/TensorRT_InferenceEngine.cpp
+++ b/botsort/src/TRT_InferenceEngine/TensorRT_InferenceEngine.cpp
@@ -312,9 +312,9 @@ bool inference_backend::TensorRTInferenceEngine::_deserialize_engine(
     engine_file.close();
 
     // Deserialize engine
-    std::unique_ptr<nvinfer1::IRuntime> runtime{
-            nvinfer1::createInferRuntime(*_logger)};
-    _engine = makeUnique(runtime->deserializeCudaEngine(
+    // Runtime must outlive the engine. Keep it as a member
+    _runtime = makeUnique(nvinfer1::createInferRuntime(*_logger));
+    _engine = makeUnique(_runtime->deserializeCudaEngine(
             trt_model_stream.data(), trt_model_stream.size()));
     if (!_engine)
     {


### PR DESCRIPTION
## Summary
- keep TensorRT runtime alive for the lifetime of the engine

## Testing
- `cmake ..` *(fails: Could not find OpenCVConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6846822fae588330869e09e0e0586e51